### PR TITLE
Hide broken image icon on clients that block images

### DIFF
--- a/email_template_2.html
+++ b/email_template_2.html
@@ -29,7 +29,7 @@
                 <tr>
                     <td width="70" bgcolor="#0b0c0c" valign="middle">
                         <!-- This asset should be hosted by the service -->
-                        <a href="https://www.gov.uk" style="text-decoration: none;"><img src="https://raw.githubusercontent.com/alphagov/email-template/master/crown-32px.gif" alt="" height="32" border="0"></a>
+                        <a href="https://www.gov.uk" style="text-decoration: none;"><img src="https://raw.githubusercontent.com/alphagov/email-template/master/crown-32px.gif" alt=" " height="32" border="0"></a>
                     </td>
                     <td width="100%" bgcolor="#0b0c0c" valign="middle" align="left">
                         <span style="padding-left: 5px;"><a href="https://www.gov.uk" style="font-family: Helvetica, Arial, sans-serif; font-size: 28px; line-height: 1.315789474; font-weight: 700; color: #efefef; text-decoration: none;">GOV.UK</a></span></a>


### PR DESCRIPTION
This Stackoverflow answer suggests that putting a space in the `alt` attribute will stop the icon from showing: http://stackoverflow.com/a/20836817/147318

It would be good to test this with EOA and see how true it is.
